### PR TITLE
refactor: separate module from runtime

### DIFF
--- a/docs/content/en/getting-started-nuxt.md
+++ b/docs/content/en/getting-started-nuxt.md
@@ -27,7 +27,7 @@ position: 2
   
     </d-code-group>
 
-    <d-alert type="info">This will also install `typed-vuex` in your project, which is where the store accessor lives. You can import its helper functions from either `nuxt-typed-vuex` or from `typed-vuex`.</d-alert>
+    <d-alert type="info">This will also install `typed-vuex` in your project, which is where the store accessor lives. All the helper functions are imported from `typed-vuex`.</d-alert>
 
 2. Add module to your `nuxt.config`:
 

--- a/examples/nuxt-ts/store/index.ts
+++ b/examples/nuxt-ts/store/index.ts
@@ -1,4 +1,4 @@
-import { getAccessorType, mutationTree, actionTree } from 'nuxt-typed-vuex'
+import { getAccessorType, mutationTree, actionTree } from 'typed-vuex'
 
 import * as submodule from './submodule'
 

--- a/examples/nuxt-ts/store/submodule.ts
+++ b/examples/nuxt-ts/store/submodule.ts
@@ -1,4 +1,4 @@
-import { getterTree, mutationTree, actionTree } from 'nuxt-typed-vuex'
+import { getterTree, mutationTree, actionTree } from 'typed-vuex'
 
 export const state = () => ({
   firstName: '',

--- a/examples/nuxt/store/index.ts
+++ b/examples/nuxt/store/index.ts
@@ -1,4 +1,4 @@
-import { getAccessorType, mutationTree, actionTree } from 'nuxt-typed-vuex'
+import { getAccessorType, mutationTree, actionTree } from 'typed-vuex'
 import { Context } from '@nuxt/types'
 
 import * as submodule from './submodule'

--- a/examples/nuxt/store/submodule.ts
+++ b/examples/nuxt/store/submodule.ts
@@ -1,4 +1,4 @@
-import { getterTree, mutationTree, actionTree } from 'nuxt-typed-vuex'
+import { getterTree, mutationTree, actionTree } from 'typed-vuex'
 
 export const state = () => ({
   firstName: '',

--- a/packages/nuxt-typed-vuex/package.json
+++ b/packages/nuxt-typed-vuex/package.json
@@ -33,15 +33,13 @@
     "dev": "nuxt test/fixture"
   },
   "dependencies": {
-    "consola": "^2.15.3",
-    "normalize-path": "^3.0.0",
-    "typed-vuex": "0.1.22"
+    "typed-vuex": "0.1.22",
+    "upath": "^2.0.1"
   },
   "devDependencies": {
     "@nuxt/test-utils": "^0.2.0",
     "@nuxt/types": "^2.15.3",
     "@nuxt/typescript-build": "^2.1.0",
-    "@types/normalize-path": "^3.0.0",
     "core-js": "3.9.1",
     "nuxt": "^2.15.3",
     "ts-loader": "^8.0.18",

--- a/packages/nuxt-typed-vuex/src/index.ts
+++ b/packages/nuxt-typed-vuex/src/index.ts
@@ -1,32 +1,29 @@
-import type { Module } from '@nuxt/types'
+import { join, resolve } from 'upath'
+
+import type { Module, NuxtOptions } from '@nuxt/types'
+
+import { name, version } from '../package.json'
 
 /**
  * @private
  */
 const nuxtTypedVuex: Module = async function() {
-  /* istanbul ignore if */
-  if (process.client || process.server) return
+  const nuxtOptions = this.nuxt.options as NuxtOptions
 
-  const { join, resolve }: typeof import('path') = process.client ? /* istanbul ignore next */  {} : require('path')
-  const normalize: typeof import('normalize-path') = process.client ? /* istanbul ignore next */  {} : require('normalize-path')
+  if (!nuxtOptions.store) console.warn('You do not have a store defined.')
 
-  if (!this.options.store) console.warn('You do not have a store defined.')
-  const buildDir = this.options.buildDir || ''
   this.addPlugin({
     src: resolve(__dirname, '../template/plugin.js'),
     fileName: 'nuxt-typed-vuex.js',
     options: {
-      store: normalize(join(buildDir, 'store')),
+      store: join(nuxtOptions.buildDir, 'store'),
     },
   })
 
-  this.options.build = this.options.build || {}
-  this.options.build.transpile = /* istanbul ignore next */ this.options.build.transpile || []
-  this.options.build.transpile.push(/typed-vuex/)
+  nuxtOptions.build.transpile = /* istanbul ignore next */ nuxtOptions.build.transpile || []
+  nuxtOptions.build.transpile.push(/typed-vuex/)
 }
 
-;(nuxtTypedVuex as any).meta = { name: 'nuxt-typed-vuex' }
-
-export * from 'typed-vuex'
+;(nuxtTypedVuex as any).meta = { name, version }
 
 export default nuxtTypedVuex

--- a/packages/nuxt-typed-vuex/src/index.ts
+++ b/packages/nuxt-typed-vuex/src/index.ts
@@ -7,7 +7,7 @@ import { name, version } from '../package.json'
 /**
  * @private
  */
-const nuxtTypedVuex: Module = async function() {
+const nuxtTypedVuex: Module = function nuxtTypedVuex() {
   const nuxtOptions = this.nuxt.options as NuxtOptions
 
   if (!nuxtOptions.store) console.warn('You do not have a store defined.')

--- a/packages/nuxt-typed-vuex/test/fixture/store/index.ts
+++ b/packages/nuxt-typed-vuex/test/fixture/store/index.ts
@@ -4,7 +4,7 @@ import {
   getAccessorType,
   mutationTree,
   actionTree,
-} from '../../../src'
+} from '../../../../typed-vuex/src'
 
 import * as submodule from './submodule'
 

--- a/packages/nuxt-typed-vuex/test/fixture/store/nuxt.ts
+++ b/packages/nuxt-typed-vuex/test/fixture/store/nuxt.ts
@@ -1,4 +1,4 @@
-import { actionTree } from '../../../src'
+import { actionTree } from '../../../../typed-vuex/src'
 
 export const state = () => ({
   n: '',

--- a/packages/nuxt-typed-vuex/test/fixture/store/submodule.ts
+++ b/packages/nuxt-typed-vuex/test/fixture/store/submodule.ts
@@ -1,4 +1,9 @@
-import { getterTree, mutationTree, actionTree, useAccessor } from '../../../src'
+import {
+  getterTree,
+  mutationTree,
+  actionTree,
+  useAccessor,
+} from '../../../../typed-vuex/src'
 import { pattern } from '.'
 
 export const state = () => ({

--- a/packages/nuxt-typed-vuex/test/module.test.ts
+++ b/packages/nuxt-typed-vuex/test/module.test.ts
@@ -1,31 +1,21 @@
 import nuxtModule from '../src'
-import path from 'path'
+
+import { setupTest, expectModuleToBeCalledWith } from '@nuxt/test-utils'
 
 describe('nuxt module', () => {
+  setupTest({
+    testDir: __dirname,
+  })
   it('exists', () => {
     expect(nuxtModule).toBeDefined()
   })
-  it('warns without store defined', () => {
-    // @ts-ignore
-    global.console = { warn: jest.fn() }
-    const addPlugin = jest.fn()
-    nuxtModule.call({
-      options: {},
-      addPlugin,
-    })
-
-    expect(console.warn).toBeCalled()
-  })
   it('adds plugin', () => {
-    const addPlugin = jest.fn()
-    nuxtModule.call({
+    expectModuleToBeCalledWith('addPlugin', {
+      src: expect.stringContaining('template/plugin.js'),
+      fileName: 'nuxt-typed-vuex.js',
       options: {
-        store: {},
+        store: expect.stringContaining('store'),
       },
-      addPlugin,
     })
-    expect(addPlugin).toHaveBeenCalled()
-    expect(addPlugin.mock.calls[0][0].options.store).toBeDefined()
-    expect(path.resolve(addPlugin.mock.calls[0][0].src)).toBeDefined()
   })
 })

--- a/packages/nuxt-typed-vuex/tsconfig.json
+++ b/packages/nuxt-typed-vuex/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "lib"
   },
   "exclude": ["node_modules", "lib", "test"]

--- a/packages/typed-vuex/test/fixture/index.ts
+++ b/packages/typed-vuex/test/fixture/index.ts
@@ -4,7 +4,7 @@ import {
   getAccessorType,
   mutationTree,
   actionTree,
-} from 'nuxt-typed-vuex'
+} from 'typed-vuex'
 
 import * as submodule from './submodule'
 

--- a/packages/typed-vuex/test/fixture/submodule.ts
+++ b/packages/typed-vuex/test/fixture/submodule.ts
@@ -1,9 +1,4 @@
-import {
-  getterTree,
-  mutationTree,
-  actionTree,
-  useAccessor,
-} from 'nuxt-typed-vuex'
+import { getterTree, mutationTree, actionTree, useAccessor } from 'typed-vuex'
 import { pattern } from '.'
 
 export const state = () => ({

--- a/packages/typed-vuex/test/tsd/accessor.test-d.ts
+++ b/packages/typed-vuex/test/tsd/accessor.test-d.ts
@@ -1,7 +1,7 @@
 import { DispatchOptions, CommitOptions } from 'vuex'
 import { expectType, expectError } from 'tsd'
 
-import { getAccessorType } from 'nuxt-typed-vuex'
+import { getAccessorType } from 'typed-vuex'
 import { getters, state, actions, mutations } from '../fixture'
 
 import * as submodule from '../fixture/submodule'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "sourceMap": true,
+    "resolveJsonModule": true,
     "declaration": true,
     "target": "esnext",
     "module": "esnext",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3697,13 +3697,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/normalize-path@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@types/normalize-path@npm:3.0.0"
-  checksum: 1cff3a34d0c0c37bca26a60e19407783fe85cde0af0ccfe7773001019c6339927460127c043163638d04f54415d165766173d9881ad8e7eb7870e4be2657ee45
-  languageName: node
-  linkType: hard
-
 "@types/optimize-css-assets-webpack-plugin@npm:^5.0.2":
   version: 5.0.2
   resolution: "@types/optimize-css-assets-webpack-plugin@npm:5.0.2"
@@ -12919,14 +12912,12 @@ fsevents@^1.2.7:
     "@nuxt/test-utils": ^0.2.0
     "@nuxt/types": ^2.15.3
     "@nuxt/typescript-build": ^2.1.0
-    "@types/normalize-path": ^3.0.0
-    consola: ^2.15.3
     core-js: 3.9.1
-    normalize-path: ^3.0.0
     nuxt: ^2.15.3
     ts-loader: ^8.0.18
     tsd: ^0.14.0
     typed-vuex: 0.1.22
+    upath: ^2.0.1
   peerDependencies:
     "@nuxt/types": ^2.15.3
   languageName: unknown


### PR DESCRIPTION
BREAKING CHANGE: all imports are now from `typed-vuex` rather than `nuxt-typed-vuex`, which is *exclusively* the module in your `nuxt.config`