### PR TITLE
docs: add $accessor typing for Nuxt context

### DIFF
--- a/docs/pages/en/1.getting-started/1.getting-started-nuxt.md
+++ b/docs/pages/en/1.getting-started/1.getting-started-nuxt.md
@@ -91,5 +91,9 @@ declare module '@nuxt/types' {
   interface NuxtAppOptions {
     $accessor: typeof accessorType
   }
+  
+  interface Context {
+    $accessor: typeof accessorType,
+  }
 }
 ```


### PR DESCRIPTION
This change allows `$accessor` typing with some nuxt modules, like https://composition-api.nuxtjs.org/API/useContext